### PR TITLE
feat(wallet-select): add loading indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
-        "@iconify/json": "^2.2.106",
+        "@iconify/icons-eos-icons": "^1.2.6",
+        "@iconify/icons-ic": "^1.2.13",
+        "@iconify/svelte": "^3.1.4",
         "@playwright/test": "^1.28.1",
         "@polkadot/typegen": "^10.9.1",
         "@sveltejs/adapter-auto": "^2.0.0",
@@ -1246,14 +1248,37 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "node_modules/@iconify/json": {
-      "version": "2.2.106",
-      "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.106.tgz",
-      "integrity": "sha512-VZXCBmSrtwutVmzgkCk6Yr9CVfl5AbEOZ/APjZbnG8+21vt91Px/nf3yXnfL6e1DAdNeZtn+iuLlVp+7cP0a3Q==",
+    "node_modules/@iconify/icons-eos-icons": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@iconify/icons-eos-icons/-/icons-eos-icons-1.2.6.tgz",
+      "integrity": "sha512-8Nk3/q2SN1qwi36w0S/CeAD55yoLfVix+85iwwVgyqz2VkILBAYUjVusfQXKIHW9KD8Vtymwz/512TXQ1GfM8Q==",
       "dev": true,
       "dependencies": {
-        "@iconify/types": "*",
-        "pathe": "^1.1.0"
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/icons-ic": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@iconify/icons-ic/-/icons-ic-1.2.13.tgz",
+      "integrity": "sha512-TphrhwOvgd7CTmUhz6jgXF+SPnMtvTm03bZsAYbny2kwq4zlkhr9e16YEyPGMvKhjtTqNooA3iZ9Wa+pZ8moXQ==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/svelte": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-3.1.4.tgz",
+      "integrity": "sha512-YDwQlN46ka8KPRayDb7TivmkAPizfTXi6BSRNqa1IV0+byA907n8JcgQafA7FD//pW5XCuuAhVx6uRbKTo+CfA==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "svelte": "*"
       }
     },
     "node_modules/@iconify/types": {
@@ -11911,14 +11936,31 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
-    "@iconify/json": {
-      "version": "2.2.106",
-      "resolved": "https://registry.npmjs.org/@iconify/json/-/json-2.2.106.tgz",
-      "integrity": "sha512-VZXCBmSrtwutVmzgkCk6Yr9CVfl5AbEOZ/APjZbnG8+21vt91Px/nf3yXnfL6e1DAdNeZtn+iuLlVp+7cP0a3Q==",
+    "@iconify/icons-eos-icons": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@iconify/icons-eos-icons/-/icons-eos-icons-1.2.6.tgz",
+      "integrity": "sha512-8Nk3/q2SN1qwi36w0S/CeAD55yoLfVix+85iwwVgyqz2VkILBAYUjVusfQXKIHW9KD8Vtymwz/512TXQ1GfM8Q==",
       "dev": true,
       "requires": {
-        "@iconify/types": "*",
-        "pathe": "^1.1.0"
+        "@iconify/types": "*"
+      }
+    },
+    "@iconify/icons-ic": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@iconify/icons-ic/-/icons-ic-1.2.13.tgz",
+      "integrity": "sha512-TphrhwOvgd7CTmUhz6jgXF+SPnMtvTm03bZsAYbny2kwq4zlkhr9e16YEyPGMvKhjtTqNooA3iZ9Wa+pZ8moXQ==",
+      "dev": true,
+      "requires": {
+        "@iconify/types": "*"
+      }
+    },
+    "@iconify/svelte": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-3.1.4.tgz",
+      "integrity": "sha512-YDwQlN46ka8KPRayDb7TivmkAPizfTXi6BSRNqa1IV0+byA907n8JcgQafA7FD//pW5XCuuAhVx6uRbKTo+CfA==",
+      "dev": true,
+      "requires": {
+        "@iconify/types": "^2.0.0"
       }
     },
     "@iconify/types": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@iconify/json": "^2.2.106",
+    "@iconify/icons-eos-icons": "^1.2.6",
+    "@iconify/icons-ic": "^1.2.13",
+    "@iconify/svelte": "^3.1.4",
     "@playwright/test": "^1.28.1",
     "@polkadot/typegen": "^10.9.1",
     "@sveltejs/adapter-auto": "^2.0.0",

--- a/src/components/SelectWallet.svelte
+++ b/src/components/SelectWallet.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
-  import DownloadBox from 'virtual:icons/ic/baseline-download';
+  import Icon from '@iconify/svelte';
+  import baselineDownload from '@iconify/icons-ic/baseline-download';
+  import threeDotsLoading from '@iconify/icons-eos-icons/three-dots-loading';
   import { onMount } from 'svelte';
-  import type { InjectedExtension } from '@polkadot/extension-inject/types';
   import { extensionsConfig } from '$lib/extensionsConfig';
   import type { Extension } from '$lib/extensionsConfig';
   import { onReady, isWalletInstalled, walletConnector } from '$lib/wallet';
+  import type { InjectedExtension } from '@polkadot/extension-inject/types';
 
   // TODO: change to false and then set to true when wallet selection is complete
   // eslint-disable-next-line @typescript-eslint/no-unused-var
   export let formFinished = true;
   export let endpoint;
+  let isLoading = false;
+  let selectedWallet: string;
 
-  let extensions: Array<Extension> = [];
+  export let extensions: Array<Extension> = [];
   let injectedWeb3: any;
 
   onMount(async () => {
@@ -21,9 +25,13 @@
 
   async function handleSelectedWallet(injectedName: string) {
     let extension: InjectedExtension;
+    isLoading = true;
+    selectedWallet = injectedName;
     try {
       extension = await walletConnector(injectedName);
+      isLoading = false;
     } catch (error) {
+      isLoading = false;
       console.log('Extension not installed - close window and redirect');
       return;
     }
@@ -46,9 +54,12 @@
           <span class="text-xs italic antialiased">Sign-in with {extension.displayName} wallet</span
           >
         </div>
-        <div class="basis-1/12">
+        <div class="basis-1/12 w-4">
           {#if !isWalletInstalled(extension.injectedName)}
-            <DownloadBox style="font-size: 1.5em; color: light-grey" />
+            <Icon icon={baselineDownload} width="30" height="30" />
+          {/if}
+          {#if isLoading && selectedWallet == extension.injectedName}
+            <Icon icon={threeDotsLoading} width="55" height="55" />
           {/if}
         </div>
       </div>

--- a/src/components/SelectWallet.test.ts
+++ b/src/components/SelectWallet.test.ts
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom';
+import { expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/svelte';
+import SelectWallet from '$components/SelectWallet.svelte';
+import { extensionsConfig } from '$lib/extensionsConfig';
+import type { InjectedExtension } from '@polkadot/extension-inject/types';
+
+describe('SelectWallet component', () => {
+  const originalWindow = global.window;
+
+  beforeAll(() => {
+    global.window.injectedWeb3 = {
+      talisman: { version: '1.8.3', enable: vi.fn() }
+    } as any as InjectedExtension; // Set your desired value here
+  });
+
+  afterAll(() => {
+    global.window = originalWindow;
+  });
+
+  it('renders the wallet buttons with correct text', async () => {
+    const { getByText } = render(SelectWallet, {
+      props: { extensions: extensionsConfig, endpoint: 'http://localhost:5171' }
+    });
+    const polkadotWalletButton = screen.getByRole('button', {
+      name: /polkadot sign\-in with polkadot wallet/i
+    });
+
+    const talismanWalletButton = screen.getByRole('button', {
+      name: /talisman sign\-in with talisman wallet/i
+    });
+
+    expect(polkadotWalletButton).toBeEnabled();
+    expect(talismanWalletButton).toBeEnabled();
+  });
+
+  it('displays loading indicator while loading', async () => {
+    const { getByTestId, container } = render(SelectWallet, {
+      props: { extensions: extensionsConfig, endpoint: 'http://localhost:5171' }
+    });
+
+    const talismanWalletButton = screen.getByRole('button', {
+      name: /talisman sign\-in with talisman wallet/i
+    });
+
+    await fireEvent.click(talismanWalletButton);
+
+    const loadingIcon = within(talismanWalletButton).getByRole('img', {
+      hidden: true
+    });
+
+    expect(loadingIcon).toBeInTheDocument();
+  });
+
+  it('displays loading indicator download icon', async () => {
+    const { getByTestId, container } = render(SelectWallet, {
+      props: { extensions: extensionsConfig, endpoint: 'http://localhost:5171' }
+    });
+
+    const talismanWalletButton = screen.getByRole('button', {
+      name: /talisman sign\-in with talisman wallet/i
+    });
+
+    await fireEvent.click(talismanWalletButton);
+
+    const downloadIcon = within(talismanWalletButton).getByRole('img', {
+      hidden: true
+    });
+
+    expect(downloadIcon).toBeInTheDocument();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "types": [
+      "unplugin-icons/types/svelte"
+    ]
   }
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
   //

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [
     sveltekit(),
     Icons({
-      compiler: 'svelte'
+      compiler: 'svelte',
     })
   ],
   resolve: {


### PR DESCRIPTION
Add a loading indicator to start when a user
selects a wallet to connect to.

issue-4

![Screenshot 2023-08-30 at 2 23 01 PM](https://github.com/AmplicaLabs/wallet-proxy/assets/3433442/55e0597c-115a-4dfd-8098-1b0377a98603)
